### PR TITLE
verbose messages could be misleading

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.3 (29/07/2019)
+* Fix slightly misleading verbose message when using recursive or
+  lazy calls
+
 ## 3.3.2 (24/05/2019)
 * Don't report `moreItems` as `true` at the end of a recursive `GET`.
 

--- a/lib/wavefront-sdk/core/api_caller.rb
+++ b/lib/wavefront-sdk/core/api_caller.rb
@@ -146,6 +146,7 @@ module Wavefront
     #
     def verbosity(conn, method, *args)
       return unless noop || verbose
+
       log format('uri: %s %s', method.upcase, conn.url_prefix)
 
       return unless args.last && !args.last.empty?
@@ -168,9 +169,6 @@ module Wavefront
     #   endpoint
     #
     def make_call(conn, method, *args)
-      verbosity(conn, method, *args)
-      return if noop
-
       paginator = paginator_class(method).new(self, conn, method, *args)
 
       case paginator.initial_limit
@@ -184,6 +182,9 @@ module Wavefront
     end
 
     def make_single_call(conn, method, *args)
+      verbosity(conn, method, *args)
+      return if noop
+
       pp args if debug
 
       resp = conn.public_send(method, *args)

--- a/lib/wavefront-sdk/defs/version.rb
+++ b/lib/wavefront-sdk/defs/version.rb
@@ -1,4 +1,4 @@
 require 'pathname'
 
-WF_SDK_VERSION = '3.3.2'.freeze
-WF_SDK_LOCATION = Pathname.new(__FILE__).dirname.parent.parent.parent
+WF_SDK_VERSION = '3.3.3'.freeze
+WF_SDK_LOCATION = Pathname.new(__dir__).parent.parent.parent

--- a/lib/wavefront-sdk/paginator/base.rb
+++ b/lib/wavefront-sdk/paginator/base.rb
@@ -100,6 +100,10 @@ module Wavefront
       def make_recursive_call
         offset = 0
         p_args = set_pagination(offset, page_size, args)
+        api_caller.verbosity(conn, method, *p_args)
+
+        return if api_caller.opts[:noop]
+
         ret = api_caller.respond(conn.public_send(method, *p_args))
 
         return ret unless ret.more_items?
@@ -137,6 +141,10 @@ module Wavefront
       def make_lazy_call
         offset = 0
         p_args = set_pagination(offset, page_size, args)
+
+        api_caller.verbosity(conn, method, *p_args)
+
+        return if api_caller.opts[:noop]
 
         Enumerator.new do |y|
           loop do


### PR DESCRIPTION
when using recursive calls the first call showed the internal SDK
override values for offset and limit, not the ones actually being used
in the API call.